### PR TITLE
Avoid error dict key missing

### DIFF
--- a/lnetatmo.py
+++ b/lnetatmo.py
@@ -185,6 +185,8 @@ class WeatherStationData:
         lastD = dict()
         # Define oldest acceptable sensor measure event
         limit = (time.time() - exclude) if exclude else 0
+        if not 'dashboard_data' in module:
+            continue      
         ds = s['dashboard_data']
         if ds['time_utc'] > limit :
             lastD[s['module_name']] = ds.copy()


### PR DESCRIPTION
When module do not have dashboard_data, it becomes error.
To avoid it, check 'dashboard_data' in module
 and if it is missing, continue.