### PR TITLE
[Fix] Don't crash MinMaxTH() on empty body

### DIFF
--- a/lnetatmo.py
+++ b/lnetatmo.py
@@ -489,7 +489,7 @@ class WeatherStationData:
                     mtype      = "Temperature,Humidity",
                     date_begin = start,
                     date_end   = end)
-        if resp:
+        if resp and resp['body']:
             T = [v[0] for v in resp['body'].values()]
             H = [v[1] for v in resp['body'].values()]
             return min(T), max(T), min(H), max(H)
@@ -881,7 +881,8 @@ def getStationMinMaxTH(station=None, module=None, home=None):
         for m in lastD.keys():
             if time.time()-lastD[m]['When'] > 3600 : continue
             r = devList.MinMaxTH(module=m)
-            result[m] = (r[0], lastD[m]['Temperature'], r[1])
+            if r:
+                result[m] = (r[0], lastD[m]['Temperature'], r[1])
     else:
         if time.time()-lastD[module]['When'] > 3600 : result = ["-", "-"]
         else :


### PR DESCRIPTION
I have an Netatmo account with old stations and modules in it that are no longer active. This means that not all data from my modules is available. I experienced this crash:
```
$ python3 lnetatmo.py 
Traceback (most recent call last):
  File "/home/dsmr/dsmr-reader/./.venv/lib/python3.9/site-packages/lnetatmo.py", line 914, in <module>
    weatherStation.MinMaxTH()                          # Test GETMEASUR
  File "/home/dsmr/dsmr-reader/./.venv/lib/python3.9/site-packages/lnetatmo.py", line 494, in MinMaxTH
    T = [v[0] for v in resp['body'].values()]
AttributeError: 'list' object has no attribute 'values'
```
I fixed this with the attached patch.