### PR TITLE
fix: name '_credentialFile' is not defined

### DIFF
--- a/lnetatmo.py
+++ b/lnetatmo.py
@@ -254,8 +254,9 @@ class ClientAuth:
             cred = {"CLIENT_ID":self._clientId,
                     "CLIENT_SECRET":self._clientSecret,
                     "REFRESH_TOKEN":self.refreshToken }
-            with open(self._credentialFile, "w") as f:
-                f.write(json.dumps(cred, indent=True))
+            if hasattr(type(self), "_credentialFile"):
+                with open(self._credentialFile, "w") as f:
+                    f.write(json.dumps(cred, indent=True))
         self._accessToken = resp['access_token']
         self.expiration = int(resp['expire_in'] + time.time())
 


### PR DESCRIPTION
This fixes an issue when `CLIENT_ID`, `CLIENT_SECRET` and `REFRESH_TOKEN` are passed, or available from the environment.