### PR TITLE
Raise exception when server response is None.

### DIFF
--- a/lnetatmo.py
+++ b/lnetatmo.py
@@ -484,6 +484,8 @@ class WeatherStationData:
                 "access_token" : self.getAuthToken
                 }
         resp = postRequest("Weather station", _GETSTATIONDATA_REQ, postParams)
+        if not resp:
+            raise AuthFailure("No response received from server.")
         self.rawData = resp['body']['devices']
         # Weather data
         if not self.rawData : raise NoDevice("No weather station in any homes")


### PR DESCRIPTION
### Summary

Currently, the `postRequest` function only handles 403 errors explicitly. For other error responses (e.g., 500 — which I tend to encounter frequently!), the function attempts to subscript a NoneType object, resulting in an ungraceful exception. This PR introduces an early exception for such cases to improve robustness and error visibility.

### Typical Error

```
2025-04-05 20:03:04: ERROR - code=500, reason=Internal Server Error, body=b'{"error":{"code":500,"message":"Internal Server Error"}}'
Traceback (most recent call last):
  <out of scope code omitted>
  File "/app/src/sensorthings_utils/netatmo.py", line 97, in _extract
    weather_station_data = ln.WeatherStationData(AUTHENTICATION)
  File "/app/.venv/lib/python3.13/site-packages/lnetatmo.py", line 460, in __init__
    self.rawData = resp['body']['devices']
                   ~~~~^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```